### PR TITLE
Fetch nested tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To install the Obsidian Tag Page Plugin:
 ### Commands
 
 - **Create Tag Page**: Trigger this command to create a new tag page or navigate to an existing one.
+  - Entering `#some-tag` will create a new tag page for `#some-tag` in the default tag page directory.
+  - Entering `#some-tag/*` will create a new tag page for all nested tags under `#some-tag` in the default tag page directory.
 
 ### Ribbon Icon
 

--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,7 @@ import {
 	Setting,
 	TFile,
 } from 'obsidian';
-import { fetchTagData } from './src/utils/tagSearch';
+import { fetchTagData, getIsWildCard } from './src/utils/tagSearch';
 import {
 	extractFrontMatterTagValue,
 	generateTagPageContent,
@@ -141,10 +141,14 @@ export default class TagPagePlugin extends Plugin {
 	async createTagPage(tag: string): Promise<void> {
 		// Append # to tag if it doesn't exist
 		const tagOfInterest = tag.startsWith('#') ? tag : `#${tag}`;
+		const { isWildCard, cleanedTag } = getIsWildCard(tagOfInterest);
+		const filename = `${cleanedTag.replace('#', '')}${
+			isWildCard ? '_nested' : ''
+		}_Tags.md`;
 
 		// Create tag page if it doesn't exist
 		const tagPage = this.app.vault.getAbstractFileByPath(
-			`${this.settings.tagPageDir}${tagOfInterest}.md`,
+			`${this.settings.tagPageDir}${filename}`,
 		);
 
 		if (!tagPage) {
@@ -160,7 +164,6 @@ export default class TagPagePlugin extends Plugin {
 				tagOfInterest,
 			);
 
-			const filename = `${tagOfInterest.replace('#', '')}_Tags.md`;
 			// if tag page doesn't exist, create it and continue
 			const exists = await this.app.vault.adapter.exists(
 				normalizePath(this.settings.tagPageDir),


### PR DESCRIPTION
Closes #3 

This PR accomplishes the following:

- Allow for nested wildcards to be captured (i.e. `#some-tag/*` captures all nested tags)
- Fixed a bug regarding how nested tags were already being included in bullet items. Nested tags must be explicitly included in query now.
- Fixed a bug regarding naming convention for a new vs. existing tag pages