### PR TITLE
Bug fixes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -45,7 +45,7 @@ export default class TagPagePlugin extends Plugin {
 		// This adds a simple command that can be triggered anywhere
 		this.addCommand({
 			id: 'create-tag-page',
-			name: 'Create Tag Page',
+			name: 'Create tag page',
 			callback: () => {
 				new CreateTagPageModal(this.app, this).open();
 			},

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -248,12 +248,7 @@ export const fetchTagData = async (
 		allFiles
 			.filter(
 				(file) =>
-					!isTagPage(
-						app,
-						settings.frontmatterQueryProperty,
-						file,
-						tagOfInterest,
-					),
+					!isTagPage(app, settings.frontmatterQueryProperty, file),
 			)
 			.map((file) => processFile(vault, settings, file, tagOfInterest)),
 	).then((tagInfos) => tagInfos.flat());


### PR DESCRIPTION
Closes #5 . Closes #9 .

Addresses two bugs:
1. Sentence case was not used for "Create tag page". Fixed per Obsidian developer guidelines.
2. Fixed a bug where Tag Pages themselves were included in the vault query, leading to duplicated lines in different pages