### PR TITLE
Case Insensitive Tags and other small fixes

### DIFF
--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -46,12 +46,7 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 				const [firstBullet, ...bullets] = tagMatch.split('\n');
 				const firstBulletWithLink = `${firstBullet} ${tagInfo.fileLink}`;
 				tagPageContent.push(
-					[firstBulletWithLink, ...bullets]
-						.join('\n')
-						.replace(
-							tagOfInterest,
-							`**${tagOfInterest.replace('#', '')}**`,
-						),
+					[firstBulletWithLink, ...bullets].join('\n'),
 				);
 			} else {
 				tagPageContent.push(

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -38,7 +38,7 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 	tagPageContent.push(
 		`---\n${settings.frontmatterQueryProperty}: "${tagOfInterest}"\n---`,
 	);
-	tagPageContent.push(`## Tag Content for ${tagOfInterest}`);
+	tagPageContent.push(`## Tag Content for ${tagOfInterest.replace('*', '')}`);
 	tagsInfo.forEach((tagInfo) => {
 		tagInfo.tagMatches.forEach((tagMatch) => {
 			// if tagMatch starts with markdown bullet, add link to first line only

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -50,12 +50,16 @@ export const getIsWildCard = (
 export const containsTag = (stringToSearch: string, tag: string): boolean => {
 	const { isWildCard, cleanedTag } = getIsWildCard(tag);
 
+	// Convert both stringToSearch and cleanedTag to the same case
+	const lowerStringToSearch = stringToSearch.toLowerCase();
+	const lowerCleanedTag = cleanedTag.toLowerCase();
+
 	if (isWildCard) {
-		return stringToSearch.includes(cleanedTag);
+		return lowerStringToSearch.includes(lowerCleanedTag);
 	} else {
-		// Match the tag followed by a single whitespace character
-		const regex = new RegExp(`${cleanedTag}\\s`, 'g');
-		return regex.test(stringToSearch);
+		// Use 'i' flag in RegExp for case-insensitive matching
+		const regex = new RegExp(`${lowerCleanedTag}\\s`, 'gi');
+		return regex.test(lowerStringToSearch);
 	}
 };
 
@@ -87,7 +91,7 @@ export const findSmallestUnitsContainingTag = (
 	// Regular expression to match the smallest unit containing the substring.
 	const regex = new RegExp(
 		`(?<=^|[\n.!?])${exclusionPattern}[^.!?\\n]*?${escapedSubstring}${wildcardPattern}[^.!?\\n]*?(?:[.!?\\n]|$)`,
-		'gm',
+		'gmi',
 	);
 
 	const matches: string[] = [];


### PR DESCRIPTION
Closes #14 .

A few small fixes:

- Obsidian tags are not case-sensitive. The plugin has been updated to reflect this behavior.
- Nested tag pages (i.e. `#some-tag/*`) would not render the `*` correctly in the header, so that was removed
- The plugin was removing the `#` from the content being reproduced on the tag page if it was found in a bullet. This was inconsistent. Perhaps it would be worth adding a config option to the user to either remove all `#` (thus removing duplication of tags) or keep them. Will consider this in the future.