### PR TITLE
Nested Tag Headers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,8 @@ export interface TagInfo {
 	fileLink: string;
 	tagMatches: string[];
 }
+
+export interface TagMatchDetail {
+	stringContainingTag: string;
+	fileLink: string;
+}

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownView } from 'obsidian';
-import { PluginSettings, TagInfo } from '../types';
+import { PluginSettings, TagInfo, TagMatchDetail } from '../types';
 
 /**
  * Type definition for a function that generates content for a tag page.
@@ -39,25 +39,30 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 		`---\n${settings.frontmatterQueryProperty}: "${tagOfInterest}"\n---`,
 	);
 	tagPageContent.push(`## Tag Content for ${tagOfInterest.replace('*', '')}`);
-	tagsInfo.forEach((tagInfo) => {
-		tagInfo.tagMatches.forEach((tagMatch) => {
-			// if tagMatch starts with markdown bullet, add link to first line only
-			if (tagMatch.trim().startsWith('-')) {
-				const [firstBullet, ...bullets] = tagMatch.split('\n');
-				const firstBulletWithLink = `${firstBullet} ${tagInfo.fileLink}`;
-				tagPageContent.push(
-					[firstBulletWithLink, ...bullets].join('\n'),
-				);
-			} else {
-				tagPageContent.push(
-					`- ${tagMatch} ${tagInfo.fileLink}`.replace(
-						tagOfInterest,
-						`**${tagOfInterest.replace('#', '')}**`,
-					),
-				);
-			}
+
+	const groupedTags = groupByTagWithDetails(tagsInfo, tagOfInterest);
+	// Check if we have more than one baseTag across all tagInfos
+	if (groupedTags.size > 1) {
+		// Iterate through each group of tags, adding a subheader for each baseTag
+		groupedTags.forEach((details, baseTag) => {
+			// Add a subheader for the baseTag
+			tagPageContent.push(`### ${baseTag}`);
+
+			// Process each tagMatch detail in this group
+			details.forEach(({ stringContainingTag, fileLink }) => {
+				processTagMatch(stringContainingTag, fileLink, baseTag, tagPageContent);
+			});
 		});
-	});
+	} else {
+		// If there's only one baseTag, process all tagMatches normally without subheaders
+		groupedTags.forEach((details) => {
+			details.forEach(({ stringContainingTag, fileLink }) => {
+				// Assuming there's only one baseTag, we can directly use the first (and only) key of groupedTags
+				const baseTag = groupedTags.keys().next().value;
+				processTagMatch(stringContainingTag, fileLink, baseTag, tagPageContent);
+			});
+		});
+	}
 
 	// Add Files with tag in frontmatter
 	const filesWithFrontmatterTag = app.vault
@@ -71,7 +76,9 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 			);
 		})
 		.map((file) => `- [[${file.basename}]]`);
+	console.log({filesWithFrontmatterTag})
 	if (filesWithFrontmatterTag.length > 0) {
+		console.log('hi')
 		tagPageContent.push(`## Files with ${tagOfInterest} in frontmatter`);
 		tagPageContent.push(...filesWithFrontmatterTag);
 	}
@@ -103,6 +110,78 @@ export const extractFrontMatterTagValue = (
 		}
 	}
 };
+
+/**
+ * Groups strings by specific tag variations from an array of TagInfo objects.
+ * Each string is already confirmed to contain the tag of interest.
+ *
+ * @param {TagInfo[]} tagInfos - An array of TagInfo objects, each with a fileLink and an array of strings that contain the tag of interest.
+ * @param {string} tagOfInterest - The tag to base the grouping on. The function will categorize the strings by the specific variations of this tag found within them.
+ * @returns {Map<string, TagMatchDetail[]>} A map where each key represents a different variation of the tag of interest found within the strings, and each value is an array of TagMatchDetail objects, which include the string containing the tag variation and the corresponding fileLink.
+ *
+ * @example
+ * const tagInfos: TagInfo[] = [
+ *     { fileLink: "file1.txt", tagMatches: ["Text with #tag1", "Another text with #tag1/nested and more"] },
+ *     { fileLink: "file2.txt", tagMatches: ["More text with #tag1/nested", "Text with another #tag2"] },
+ * ];
+ * const tagOfInterest = "#tag1";
+ * const groupedTags = groupByTagWithDetails(tagInfos, tagOfInterest);
+ * console.log(groupedTags);
+ */
+function groupByTagWithDetails(tagInfos: TagInfo[], tagOfInterest: string): Map<string, TagMatchDetail[]> {
+	const grouped = new Map<string, TagMatchDetail[]>();
+
+	tagInfos.forEach(tagInfo => {
+		tagInfo.tagMatches.forEach(stringContainingTag => {
+			// Directly use the tagOfInterest to form the basis of the grouping
+			const regexPattern = tagOfInterest.replace(/[#/]/g, "\\$&") + "(\\w|[-/])*";
+			const regex = new RegExp(regexPattern, 'g');
+
+			const matches = stringContainingTag.match(regex);
+			if (matches) {
+				matches.forEach(match => {
+					const tagDetail: TagMatchDetail = { stringContainingTag, fileLink: tagInfo.fileLink };
+					// Ensure a group for this tag variation exists
+					if (!grouped.has(match)) {
+						grouped.set(match, [tagDetail]);
+					} else {
+						grouped.get(match)?.push(tagDetail);
+					}
+				});
+			}
+		});
+	});
+
+	return grouped;
+}
+
+/**
+ * Processes a single tag match, formatting it according to the specified logic and appending it to the provided content array.
+ * If the tag match starts with a markdown bullet ('-'), the function formats the first line with the file link and preserves the rest as is.
+ * Otherwise, it prefixes the tag match with a markdown bullet, highlights the base tag within the match, and appends the file link.
+ *
+ * @param {string} fullTag - The full tag match string, which may include additional content beyond the base tag.
+ * @param {string} fileLink - The URL or path to the file associated with the tag match.
+ * @param {string} baseTag - The base tag extracted from the full tag match, used for highlighting within the formatted output.
+ * @param {string[]} tagPageContent - The array to which the formatted tag match will be appended. This array accumulates the content for a page or section.
+ */
+function processTagMatch(fullTag: string, fileLink: string, baseTag: string, tagPageContent: string[]) {
+	if (fullTag.trim().startsWith('-')) {
+		const [firstBullet, ...bullets] = fullTag.split('\n');
+		const firstBulletWithLink = `${firstBullet} ${fileLink}`;
+		tagPageContent.push(
+			[firstBulletWithLink, ...bullets].join('\n'),
+		);
+	} else {
+		tagPageContent.push(
+			`- ${fullTag} ${fileLink}`.replace(
+				baseTag,
+				`**${baseTag.replace('#', '')}**`,
+			),
+		);
+	}
+}
+
 
 /**
  * Swaps the content of the current page in view with new content.

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -74,7 +74,7 @@ export const containsTag = (stringToSearch: string, tag: string): boolean => {
 export const findSmallestUnitsContainingTag = (
 	content: string,
 	tag: string,
-	excludeBullets: boolean = false,
+	excludeBullets = false,
 ): string[] => {
 	// Check if tag has the wildcard /* at the end
 	const { isWildCard, cleanedTag } = getIsWildCard(tag);
@@ -102,7 +102,7 @@ export const findSmallestUnitsContainingTag = (
 		matches.push(match[0].trim());
 	}
 
-	return matches.length > 0 ? matches : [];
+	return matches;
 };
 
 /**


### PR DESCRIPTION
- Closes #13 

1. **New Feature**: On wildcard pages, breaks content into headers based on different subdivisions of wildcards
2. **Bug Fix**: Fixes a bug where wildcard tags in frontmatter were not captured in the Tag Page frontmatter section
3. Refactored several bits of functionality into smaller unit functions