### PR TITLE
Duckfarts fix create tag page for nested

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,7 @@ import { isTagPage } from './src/utils/obsidianApi';
 const DEFAULT_SETTINGS: PluginSettings = {
 	tagPageDir: 'Tags/',
 	frontmatterQueryProperty: 'tag-page-query',
+	nestedSeparator: '_',
 	bulletedSubItems: true,
 	includeLines: true,
 	autoRefresh: true,
@@ -142,9 +143,8 @@ export default class TagPagePlugin extends Plugin {
 		// Append # to tag if it doesn't exist
 		const tagOfInterest = tag.startsWith('#') ? tag : `#${tag}`;
 		const { isWildCard, cleanedTag } = getIsWildCard(tagOfInterest);
-		const filename = `${cleanedTag.replace("#", "").replaceAll("/","_")}${
-			isWildCard ? '_nested' : ''
-		}_Tags.md`;
+		const filename = `${cleanedTag.replace("#", "").replaceAll("/", this.settings.nestedSeparator)}${isWildCard ? this.settings.nestedSeparator + 'nested' : ''
+			}` + this.settings.nestedSeparator + `Tags.md`;
 
 		// Create tag page if it doesn't exist
 		const tagPage = this.app.vault.getAbstractFileByPath(
@@ -275,7 +275,19 @@ class TagPageSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}),
 			);
-
+		new Setting(containerEl)
+			.setName('Nested page separator')
+			.setDesc(
+				"Text used to separate levels for nested tags. Avoid \\/<>:\"|?* and other characters that aren't file-safe, or you won't be able to make pages for nested tags.",
+			)
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.nestedSeparator)
+					.onChange(async (value) => {
+						this.plugin.settings.nestedSeparator = value;
+						await this.plugin.saveSettings();
+					}),
+			);
 		new Setting(containerEl)
 			.setName('Include lines')
 			.setDesc('Include lines containing the tag in the tag page.')

--- a/main.ts
+++ b/main.ts
@@ -142,7 +142,7 @@ export default class TagPagePlugin extends Plugin {
 		// Append # to tag if it doesn't exist
 		const tagOfInterest = tag.startsWith('#') ? tag : `#${tag}`;
 		const { isWildCard, cleanedTag } = getIsWildCard(tagOfInterest);
-		const filename = `${cleanedTag.replace('#', '')}${
+		const filename = `${cleanedTag.replace("#", "").replaceAll("/","_")}${
 			isWildCard ? '_nested' : ''
 		}_Tags.md`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface PluginSettings {
 	tagPageDir: string;
 	frontmatterQueryProperty: string;
+	nestedSeparator: string;
 	bulletedSubItems: boolean;
 	includeLines: boolean;
 	autoRefresh: boolean;

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -255,7 +255,7 @@ export const processFile = async (
 	switch (true) {
 		case settings.bulletedSubItems && settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,
@@ -265,14 +265,14 @@ export const processFile = async (
 			);
 		case settings.bulletedSubItems && !settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				undefined,
 				findBulletListsContainingTag(fileContents, tagOfInterest),
 			);
 		case !settings.bulletedSubItems && settings.includeLines:
 		default:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -255,7 +255,7 @@ export const processFile = async (
 	switch (true) {
 		case settings.bulletedSubItems && settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,
@@ -265,14 +265,14 @@ export const processFile = async (
 			);
 		case settings.bulletedSubItems && !settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				undefined,
 				findBulletListsContainingTag(fileContents, tagOfInterest),
 			);
 		case !settings.bulletedSubItems && settings.includeLines:
 		default:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,


### PR DESCRIPTION
Fix for **Creating a tag page for a nested tag doesn't work #20**
- Replaces the `/` symbols in tag names with `_` when creating filenames