### PR TITLE
Enhancement: Table output

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -142,7 +142,7 @@ export default class TagPagePlugin extends Plugin {
 		// Append # to tag if it doesn't exist
 		const tagOfInterest = tag.startsWith('#') ? tag : `#${tag}`;
 		const { isWildCard, cleanedTag } = getIsWildCard(tagOfInterest);
-		const filename = `${cleanedTag.replace("#", "").replaceAll("/","_")}${
+		const filename = `${cleanedTag.replace('#', '')}${
 			isWildCard ? '_nested' : ''
 		}_Tags.md`;
 

--- a/main.ts
+++ b/main.ts
@@ -142,7 +142,7 @@ export default class TagPagePlugin extends Plugin {
 		// Append # to tag if it doesn't exist
 		const tagOfInterest = tag.startsWith('#') ? tag : `#${tag}`;
 		const { isWildCard, cleanedTag } = getIsWildCard(tagOfInterest);
-		const filename = `${cleanedTag.replace('#', '')}${
+		const filename = `${cleanedTag.replace("#", "").replaceAll("/","_")}${
 			isWildCard ? '_nested' : ''
 		}_Tags.md`;
 

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -40,6 +40,8 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 		`---\n${settings.frontmatterQueryProperty}: "${tagOfInterest}"\n---`,
 	);
 	tagPageContent.push(`## Tag Content for ${tagOfInterest.replace('*', '')}`);
+	tagPageContent.push(`| Link | Tags/Content |`);
+	tagPageContent.push(`| --- | --- |`);
 
 	// Check if we have more than one baseTag across all tagInfos
 	if (tagsInfo.size > 1) {
@@ -130,10 +132,10 @@ function processTagMatch(
 ) {
 	if (fullTag.trim().startsWith('-')) {
 		const [firstBullet, ...bullets] = fullTag.split('\n');
-		const firstBulletWithLink = `${firstBullet} ${fileLink}`;
+    	const firstBulletWithLink = `| ${fileLink} | ${firstBullet} |`;
 		tagPageContent.push([firstBulletWithLink, ...bullets].join('\n'));
 	} else {
-		tagPageContent.push(`- ${fullTag} ${fileLink}`);
+		tagPageContent.push(`| ${fileLink} | ${fullTag} |`);
 	}
 }
 

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -40,8 +40,6 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 		`---\n${settings.frontmatterQueryProperty}: "${tagOfInterest}"\n---`,
 	);
 	tagPageContent.push(`## Tag Content for ${tagOfInterest.replace('*', '')}`);
-	tagPageContent.push(`| Link | Tags/Content |`);
-	tagPageContent.push(`| --- | --- |`);
 
 	// Check if we have more than one baseTag across all tagInfos
 	if (tagsInfo.size > 1) {
@@ -55,7 +53,8 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 		sortedTagsInfo.forEach(([baseTag, details]) => {
 			// Add a subheader for the baseTag
 			tagPageContent.push(`### ${baseTag}`);
-
+			tagPageContent.push(`| Link | Tags/Content |`);
+			tagPageContent.push(`| --- | --- |`);
 			// Process each tagMatch detail in this group
 			details.forEach(({ stringContainingTag, fileLink }) => {
 				processTagMatch(stringContainingTag, fileLink, tagPageContent);
@@ -63,6 +62,8 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 		});
 	} else {
 		// If there's only one baseTag, process all tagMatches normally without subheaders
+		tagPageContent.push(`| Link | Tags/Content |`);
+		tagPageContent.push(`| --- | --- |`);
 		tagsInfo.forEach((details) => {
 			details.forEach(({ stringContainingTag, fileLink }) => {
 				// Assuming there's only one baseTag, we can directly use the first (and only) key of groupedTags

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -255,7 +255,7 @@ export const processFile = async (
 	switch (true) {
 		case settings.bulletedSubItems && settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,
@@ -265,14 +265,14 @@ export const processFile = async (
 			);
 		case settings.bulletedSubItems && !settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				undefined,
 				findBulletListsContainingTag(fileContents, tagOfInterest),
 			);
 		case !settings.bulletedSubItems && settings.includeLines:
 		default:
 			return consolidateTagInfo(
-				`[[${file.basename}|*]]`,
+				`[[${file.basename}]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,

--- a/src/utils/tagSearch.ts
+++ b/src/utils/tagSearch.ts
@@ -255,7 +255,7 @@ export const processFile = async (
 	switch (true) {
 		case settings.bulletedSubItems && settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,
@@ -265,14 +265,14 @@ export const processFile = async (
 			);
 		case settings.bulletedSubItems && !settings.includeLines:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				undefined,
 				findBulletListsContainingTag(fileContents, tagOfInterest),
 			);
 		case !settings.bulletedSubItems && settings.includeLines:
 		default:
 			return consolidateTagInfo(
-				`[[${file.basename}]]`,
+				`[[${file.basename}|*]]`,
 				findSmallestUnitsContainingTag(
 					fileContents,
 					tagOfInterest,


### PR DESCRIPTION
Please note that this also incorporates:
- Fix: Fixes issue with creating tag pages for nested tags
- Enhancement: Shows full link name instead of *

These needed to be included for the table output to work properly. Both of these are also available in separate pull requests.

Enhancement: Table output
- Outputs links in tables instead of lists
- Wildcard tag pages have separate tables for different links

Please note that tags that were used in bullet lists with additional bullets under them (hiearchically) create additional table rows on tag pages. i'd like to keep them in the same table cell using `<br />` tags, but I haven't figured out how to do that yet.