### PR TITLE
Feature: Adding template of the tag page title to the settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ To install the Obsidian Tag Page Plugin:
 - **Sort By Date**: Sorts content by creation date. Defaults to descending (newest content first)
 - **Nested page separator**: Indicate the character used between words when created tag pages. Defaults to `_`.
    - _Example_: `mytag_nested.md`
+- **Tag page title template**: Template for the titles of the tag pages. If left empty, a default title will be generated: `Tag Content for {{tag}}`.There are three (case sensitive) placeholders available:
+   - `{{tag}}`: Will by replaced by the actual tag with a link (e.g. `#Birds`).
+   - `{{tagname}}`: Will be replaced by the tag name without the `#` symbol and without a link (e.g. `Birds` if the tag is `#Birds`).
+   - `{{lf}}`: Will be replaced by a newline (line feed). With this placeholder, you can add spacing or static text between the title and the tags.
 - **Include Lines**: Choose to include lines containing the tag in the tag page.
 - **Bulleted Sub Items**: Choose to include bulleted sub-items containing the tag in the tag page.
 - **Display Full Link Names**: When off, referenced content will end with a link aliased as `*`. When toggled on, it will use the full file name for the link.

--- a/main.ts
+++ b/main.ts
@@ -313,7 +313,7 @@ class TagPageSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Tag page title template')
 			.setDesc(
-				'Title template for the tag page. The placeholder \'{{tag}}\' will be replaced by the actual tag. The placeholder \'{{tagname}}\' will be replaced just by the tag name (without # and link). The placeholder \'{{lf}}\' (line feed) is used to add new lines, for optional spacing or to add a static text between the title and the tags.'
+				'Title template for the tag page. The placeholder \'{{tag}}\' will be replaced by the actual tag. The placeholder \'{{tagname}}\' will be replaced by just the tag name (without the \'#\' symbol and without a link). The placeholder \'{{lf}}\' (line feed) is used to add new lines for optional spacing or to insert static text between the title and the tags.'
 			)
 			.addText((text) =>
 				text

--- a/main.ts
+++ b/main.ts
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	frontmatterQueryProperty: 'tag-page-query',
 	sortByDate: SortOrder.DESC,
 	nestedSeparator: '_',
+	tagPageTitleTemplate: 'Tag Content for {{tag}}',
 	bulletedSubItems: true,
 	includeLines: true,
 	autoRefresh: true,
@@ -308,6 +309,19 @@ class TagPageSettingTab extends PluginSettingTab {
 						this.plugin.settings.nestedSeparator = value;
 						await this.plugin.saveSettings();
 					}),
+			);
+		new Setting(containerEl)
+			.setName('Tag page title template')
+			.setDesc(
+				'Title template for the tag page. The placeholder \'{{tag}}\' will be replaced by the actual tag. The placeholder \'{{tagname}}\' will be replaced just by the tag name (without # and link). The placeholder \'{{lf}}\' (line feed) is used to add new lines, for optional spacing or to add a static text between the title and the tags.'
+			)
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.tagPageTitleTemplate)
+					.onChange(async (value) => {
+						this.plugin.settings.tagPageTitleTemplate = value;
+						await this.plugin.saveSettings();
+					})
 			);
 		new Setting(containerEl)
 			.setName('Include lines')

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface PluginSettings {
 	frontmatterQueryProperty: string;
 	sortByDate: SortOrder;
 	nestedSeparator: string;
+	tagPageTitleTemplate: string;
 	bulletedSubItems: boolean;
 	includeLines: boolean;
 	autoRefresh: boolean;

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -215,6 +215,6 @@ export const resolveTagPageTitle = (
 	} else {
 		const tag = `${tagOfInterest.replace('*', '')}`;
 		const tagName = `${tagOfInterest.replace('*', '')}`.replace('#','');
-		return  '## ' + template.replaceAll('{{lf}}','\n').replaceAll('{{tag}}', tag).replaceAll('{{tagname}}', tagName);
+		return  '## ' + template.replaceAll('{{lf}}','\n').replaceAll('{{tag}}', ' ' + tag).replaceAll('{{tagname}}', tagName).replaceAll('  ', ' ');
 	}
 }

--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -39,7 +39,8 @@ export const generateTagPageContent: GenerateTagPageContentFn = async (
 	tagPageContent.push(
 		`---\n${settings.frontmatterQueryProperty}: "${tagOfInterest}"\n---`,
 	);
-	tagPageContent.push(`## Tag Content for ${tagOfInterest.replace('*', '')}`);
+	// Resolve the title and push to the page content
+	tagPageContent.push(resolveTagPageTitle(settings, tagOfInterest));
 
 	// Check if we have more than one baseTag across all tagInfos
 	if (tagsInfo.size > 1) {
@@ -196,3 +197,24 @@ export const generateFilename = (
 		isWildCard ? nestedSeparator + 'nested' : ''
 	}${nestedSeparator}Tags.md`;
 };
+
+/**
+ * Resolves the title of the tag page according to the defined template in the settings. 
+ * If empty, the default title will be generated. The template variable {{tag}} will be replaced by the full tag, and {{tagname}} will be replaced just with the tag name. {{lf}} will create new lines.
+ * @param {PluginSettings} settings - The plugin settings.
+ * @param {string} tagOfInterest - The tag for which the page is being generated.
+ * @returns The resolved page title
+ */
+export const resolveTagPageTitle = (
+	settings: PluginSettings,
+	tagOfInterest: string,
+): string => {
+	const template = settings.tagPageTitleTemplate;
+	if (!template) {
+		return `## Tag Content for ${tagOfInterest.replace('*', '')}`;
+	} else {
+		const tag = `${tagOfInterest.replace('*', '')}`;
+		const tagName = `${tagOfInterest.replace('*', '')}`.replace('#','');
+		return  '## ' + template.replaceAll('{{lf}}','\n').replaceAll('{{tag}}', tag).replaceAll('{{tagname}}', tagName);
+	}
+}


### PR DESCRIPTION
## Subject
This PR introduces a new field for the tag page title in the settings of the plugin. The title, that was previously the static text , `## Tag Content for ${tagOfInterest.replace('*', '')}` is now designed as template that accepts the following placeholders:
 - `{{tag}}` : Is replaced by the tag (e.g. `#Animals`)
 - `{{tagname}}` : Is replaced just by the tag name without linkage (e.g. `Animals`)
 - `{{lf}}` (line feed) : is replaced by \n. This make it possible to add further static text after the title or to add some spacing between the title and the tags

## Changes
- Adaption of the settings (added one new string field "Tag page title template")
- Adaption of types.ts due to a new parameter in main.ts
- Added function resolveTagPageTitle in pageContent.ts
- Replaced static title in pageContent.ts by a call of resolveTagPageTitle

## Advantages
- Users can customize the title of their generated tag pages
- It is possible to localize the page titles
- If not desired, the page title is not rendered with the tag as link, but just the tag name, using the placeholder `{{tagname}}`
- It is possible to add the tag and/or tag title multiple times in the template
- It is possible to enforce some spacing between the title and the tags, using `{{lf}}`

## Actions / Testing
- The feature was tested for proper execution (crashes, syntax errors)
- The feature was tested with several strings and empty values (fallback on empty/null is ensured)
- The feature was tested with multiple {{tag}}, {{tagname}}  and {{lf}} tokens in the template text
- The feature was tested for sanitizing the template (e.g. <script> tags are not interpreted)
- It was tested that the adaption are not changing any other behavior of the plugin than the title generation 