### PR TITLE
pageContent: split tags if its not an array

### DIFF
--- a/src/utils/pageContent.ts
+++ b/src/utils/pageContent.ts
@@ -150,7 +150,7 @@ function matchesTagOfInterest(
 	tagOfInterest: string,
 ): boolean {
 	// Normalize tags to an array
-	const normalizedTags = Array.isArray(tags) ? tags : [tags];
+	const normalizedTags = Array.isArray(tags) ? tags : tags.split(' ').map((tag) => tag.trim());
 
 	// Prepare base tag and regex pattern for matching
 	const { isWildCard, cleanedTag: tagBase } = getIsWildCard(tagOfInterest);


### PR DESCRIPTION
Tags may be space-separated, which is rendered by Obsidian correctly but represented as a single string. Instead of putting the entire string in the array we should split and trim it.

Fixes #40 